### PR TITLE
Expose debug log

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -72,6 +72,8 @@ const POPUP = 'popup';
 
 const REMOVE_ACTION = 'remove_action';
 
+const GET_DEBUG_LOG = 'get_debug_log';
+
 Object.assign(exports, {
   DISK_NAME,
   responses,
@@ -95,6 +97,7 @@ Object.assign(exports, {
   TAB_DEACTIVATE_HEADERS,
   POPUP,
   REMOVE_ACTION,
+  GET_DEBUG_LOG,
 });
 
 })].map(func => typeof exports == 'undefined' ? define('/constants', func) : func(exports));

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -84,7 +84,7 @@ class Popup {
       tabId: this.tabId,
     },
     debugString => {
-      return navigator.clipboard.writeText(debugString);
+      console.log(debugString);
     });
   }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -35,6 +35,7 @@ class Popup {
     this.getClickHandler = this.handler.getFunc.bind(this.handler);
 
     $('on-off').onclick = this.onOff.bind(this);
+    $('debug-link').onclick = this.debug.bind(this);
   }
 
   connect() {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -13,7 +13,7 @@ let {connect, document, sendMessage, getURL} = require('./shim'),
   {PopupHandler} = require('./reasons/handlers'),
   {View, Counter} = require('./utils'),
   {Action} = require('./schemes'),
-  {POPUP, USER_URL_DEACTIVATE, USER_HOST_DEACTIVATE, HEADER_DEACTIVATE_ON_HOST} = require('./constants');
+  {GET_DEBUG_LOG, POPUP, USER_URL_DEACTIVATE, USER_HOST_DEACTIVATE, HEADER_DEACTIVATE_ON_HOST} = require('./constants');
 
 function makeCheckbox(checked, handler) {
   let checkbox = document.createElement('input');
@@ -74,6 +74,16 @@ class Popup {
       type: HEADER_DEACTIVATE_ON_HOST,
       tabId: this.tabId,
       checked: $('header-checkbox').checked
+    });
+  }
+
+  async debug() {
+    await sendMessage({
+      type: GET_DEBUG_LOG,
+      tabId: this.tabId,
+    },
+    debugString => {
+      return navigator.clipboard.writeText(debugString);
     });
   }
 

--- a/src/js/popup_server.js
+++ b/src/js/popup_server.js
@@ -4,7 +4,7 @@
 
 let {onConnect} = require('./shim'),
     {POPUP} = require('./constants'),
-    {Model, currentTab} = require('./utils');
+    {Model, currentTab, log} = require('./utils');
 
 class Server {
   constructor(tabs) {
@@ -16,9 +16,11 @@ class Server {
     onConnect.addListener(port => {
       if (port.name === POPUP) {
         currentTab().then(tab => {
+          log(`Opening popup for tab: ${tab.id}`);
           let model = new Model(port, this.tabs.getTab(tab.id));
           this.connections.set(tab.id, model);
           port.onDisconnect.addListener(() => {
+            log(`Removing popup connection for tab: ${tab.id}`);
             this.connections.delete(tab.id);
             model.delete();
           });

--- a/src/js/possum.js
+++ b/src/js/possum.js
@@ -9,7 +9,7 @@ const constants = require('./constants'),
   {Handler, MessageHandler} = require('./reasons/handlers'),
   {WebRequest} = require('./webrequest'),
   PopupServer = require('./popup_server').Server,
-  {log} = require('./utils');
+  {prettyLog, log} = require('./utils');
 
 class Possum {
   constructor(store = new DomainStore(constants.DISK_NAME)) {
@@ -31,6 +31,10 @@ class Possum {
 
   static async load(disk) {
     return new Possum(await DomainStore.load(constants.DISK_NAME, disk));
+  }
+
+  prettyLog() {
+    return prettyLog();
   }
 }
 

--- a/src/js/reasons/handlers.js
+++ b/src/js/reasons/handlers.js
@@ -74,8 +74,8 @@ class MessageHandler extends Dispatcher {
     super('messageHandler', {tabs, store}, reasons);
   }
 
-  dispatcher(messenger, sender) {
-    return super.dispatcher(messenger.type, [messenger, sender]);
+  dispatcher(messenger, sender, sendResponse) {
+    return super.dispatcher(messenger.type, [messenger, sender, sendResponse]);
   }
 
   startListeners(onMessage = shim.onMessage) {

--- a/src/js/reasons/reasons.js
+++ b/src/js/reasons/reasons.js
@@ -5,10 +5,10 @@
 const {Action} = require('../schemes'),
   {setResponse, sendUrlDeactivate} = require('./utils'),
   {URL} = require('../shim'),
-  {Listener, setTabIconActive, hasAction} = require('../utils'),
+  {Listener, log, logger, setTabIconActive, hasAction} = require('../utils'),
   constants = require('../constants');
 
-const {NO_ACTION, CANCEL, BLOCK,
+const {NO_ACTION, CANCEL, BLOCK, GET_DEBUG_LOG,
     USER_HOST_DEACTIVATE, TAB_DEACTIVATE, REMOVE_ACTION} = constants;
 
 /**
@@ -131,6 +131,15 @@ const reasonsArray = [
     name: REMOVE_ACTION,
     props: {
       messageHandler: onRemoveAction,
+    },
+  },
+  {
+    name: GET_DEBUG_LOG,
+    props: {
+      messageHandler: ({}, messenger, sender, sendResponse) => {
+        log('got GET_DEBUG_LOG msg');
+        return sendResponse(logger.dump());
+      },
     },
   },
 ];

--- a/src/js/reasons/reasons.js
+++ b/src/js/reasons/reasons.js
@@ -138,7 +138,7 @@ const reasonsArray = [
     props: {
       messageHandler: ({}, messenger, sender, sendResponse) => {
         log('got GET_DEBUG_LOG msg');
-        return sendResponse(logger.dump());
+        return sendResponse(logger.prettyLog());
       },
     },
   },

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -173,6 +173,16 @@ class LogBook extends FifoMap {
     return Array.from(this).reverse();
   }
 
+  prettyLog() {
+    let out = '!!! This log may contain information about your browisng !!!';
+    for (let [i, entry] of this.dump()) {
+      out += `
+      ${i}:
+        ${entry}`
+    }
+    return out;
+  }
+
   log(entry) {
     if (this.print) {
       console.log(entry); // eslint-disable-line
@@ -318,7 +328,7 @@ function zip() {
 
 lazyDef(exports, 'log', () => {
   let logger = new LogBook(100);
-  return {logger, log: logger.log.bind(logger)};
+  return {logger, log: logger.log.bind(logger), prettyLog: logger.prettyLog.bind(logger)};
 });
 
 Object.assign(exports, {

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -43,6 +43,6 @@
     </div>
   </div>
   <footer>
-    <a href="https://github.com/cowlicks/privacypossum/issues" rel="noopener noreferrer" target="_blank">Report a bug</a>
+    <a id="debug-link" href="#">Report a bug</a>
   </footer>
 </body>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -43,6 +43,6 @@
     </div>
   </div>
   <footer>
-    <a id="debug-link" href="#">Report a bug</a>
+    <a id="debug-link" href="https://github.com/cowlicks/privacypossum/issues" rel="noopener noreferrer" target="_blank">Report a bug</a>
   </footer>
 </body>


### PR DESCRIPTION
This closes #36 and make bug reports much more helpful.

Edit: the debug log is now exposed in the console. If the user wants to access it they can inspect the popup and run: `popup.debug();` or from the bacground console they can run `possum.prettyLog();`

~~Currently this copies the debug log to the clipboard when the link is clicked.~~ 