### PR TITLE
Make fingerprinting script more robust

### DIFF
--- a/src/js/test/fingercounting_test.js
+++ b/src/js/test/fingercounting_test.js
@@ -53,6 +53,10 @@ describe('fingercounting.js', function() {
         '@https://duckduckgo.com/d2395.js:1:144567',
         'https://duckduckgo.com/d2395.js',
       ],
+      [
+        "    at https://online.citi.com/CBOL/common/js/jfp.combined.min.js:68:4324",
+        "https://online.citi.com/CBOL/common/js/jfp.combined.min.js",
+      ],
     ];
     it('extracts urls correctly', function() {
       data.forEach(([line, expected]) => assert.equal(getUrlFromStackLine(line), expected));

--- a/src/js/web_accessible/fingercounting.js
+++ b/src/js/web_accessible/fingercounting.js
@@ -38,7 +38,7 @@ const urlEndRegex = /^.*?.(?=(\?|#|:(?!\/\/)))/,
   startsWithHttpScheme = /^https?:\/\//;
 
 function getUrlFromStackLine(line) {
-  while (line.endsWith(')')) { // there are parenthese
+  while (line.slice(-1) === ')') { // there are parenthese
     line = line.slice(line.lastIndexOf('(') + 1);
     line = line.slice(0, line.indexOf(')'));
   }

--- a/src/js/web_accessible/fingercounting.js
+++ b/src/js/web_accessible/fingercounting.js
@@ -28,9 +28,13 @@ function listen(func) {
 function getScriptLocation() {  // todo: to do split('\n') we do a O(n) read of the stack, this could be reduced by a constant factor by only reading to the third '\n'. but this is micro optimisation
   let lines = (new Error()).stack.split('\n');
   try {
-    return getUrlFromStackLine(lines[3]);
-  } catch (e) {
-    return getUrlFromStackLine(lines[2]);
+    try {
+      return getUrlFromStackLine(lines[3]);
+    } catch (e) {
+      return getUrlFromStackLine(lines[2]);
+    }
+  } catch (ee) {
+    return null;
   }
 }
 


### PR DESCRIPTION
This is partially a workaround to close #26 

We also now give up, instead of failing, after trying to get the script location twice.

Later we should copy native versions of things like `String.prototype.endsWith` so website code can't intentionally interfere with anti-fingerprinting code.