### PR TITLE
Fail gracefully getting data if it is missing

### DIFF
--- a/src/js/disk_map.js
+++ b/src/js/disk_map.js
@@ -67,7 +67,9 @@ class DiskMap {
 
   get(key) {
     return new Promise(resolve => {
-      this.disk.get((this.name + key), keyValue => resolve(keyValue[1]));
+      this.disk.get((this.name + key), keyValue => {
+        return resolve(typeof keyValue !== 'undefined' ? keyValue[1]: undefined);
+      });
     });
   }
 


### PR DESCRIPTION
Closes #38 

This disk can get into an inconsistent state for whatever reason, so we need to fail gracefully if our record keeping doesn't match what is on disk.