### PR TITLE
Etag clean up

### DIFF
--- a/src/js/disk_map.js
+++ b/src/js/disk_map.js
@@ -28,7 +28,7 @@ class DiskMap {
   }
 
   async loadKeys() {
-    this.keys = await this.getKeys();
+    return this.keys = await this.getKeys();
   }
 
   async getKeys() {

--- a/src/js/reasons/etag.js
+++ b/src/js/reasons/etag.js
@@ -17,11 +17,11 @@ async function setEtagAction(store, url, reason, data={etagValue: null}) {
 }
 
 function newEtagHeaderFunc(store) {
-  let unknownEtagCache = new LruMap(2000);
-  return etagHeader.bind(undefined, {store, unknownEtagCache});
+  let unknownEtags = new LruMap(2000);
+  return etagHeader.bind(undefined, {store, unknownEtags});
 }
 
-function etagHeader({store, unknownEtagCache}, details, header) {
+function etagHeader({store, unknownEtags}, details, header) {
   const {protocol, host, pathname} = details.urlObj,
     url  = `${protocol}//${host}${pathname}`,
     etagValue = header.value,
@@ -34,9 +34,9 @@ function etagHeader({store, unknownEtagCache}, details, header) {
       return false;
     }
   }
-  if (unknownEtagCache.has(url)) {
-    let oldEtagValue = unknownEtagCache.get(url).etagValue;
-    unknownEtagCache.delete(url)
+  if (unknownEtags.has(url)) {
+    let oldEtagValue = unknownEtags.get(url).etagValue;
+    unknownEtags.delete(url)
     if (etagValue === oldEtagValue) {
       // mark ETAG_SAFE
       setEtagAction(store, url, ETAG_SAFE, {etagValue});
@@ -48,7 +48,7 @@ function etagHeader({store, unknownEtagCache}, details, header) {
       return true;
     }
   } else {
-    unknownEtagCache.set(url, {etagValue});
+    unknownEtags.set(url, {etagValue});
     return true;
   }
 }

--- a/src/js/reasons/etag.js
+++ b/src/js/reasons/etag.js
@@ -7,19 +7,20 @@ const {etag: {ETAG_TRACKING, ETAG_SAFE}} = require('../constants'),
   {sendUrlDeactivate} = require('./utils'),
   {Action} = require('../schemes');
 
-async function setEtagAction(store, href, reason, data={etagValue: null}) {
+async function setEtagAction(store, url, reason, data={etagValue: null}) {
     log(`etag update with:
       reason: ${reason}
-      url: ${href}
+      url: ${url}
       etag value: ${data.etagValue}`);
     data.time = Date.now();
-    return await store.setUrl(href, new Action(reason, data));
+    return await store.setUrl(url, new Action(reason, data));
 }
 
 function etagHeader({store, cache}, details, header) {
-  const {href} = details.urlObj,
+  const {protocol, host, pathname} = details.urlObj,
+    url  = `${protocol}//${host}${pathname}`,
     etagValue = header.value,
-    action = store.getUrl(href);
+    action = store.getUrl(url);
   if (action) {
     if (action.reason === ETAG_TRACKING) {
       Object.assign(details, {action})
@@ -28,21 +29,21 @@ function etagHeader({store, cache}, details, header) {
       return false;
     }
   }
-  if (cache.has(href)) {
-    let oldEtagValue = cache.get(href).etagValue;
-    cache.delete(href)
+  if (cache.has(url)) {
+    let oldEtagValue = cache.get(url).etagValue;
+    cache.delete(url)
     if (etagValue === oldEtagValue) {
       // mark ETAG_SAFE
-      setEtagAction(store, href, ETAG_SAFE, {etagValue});
+      setEtagAction(store, url, ETAG_SAFE, {etagValue});
       return false;
     } else {
       // mark ETAG_TRACKING
-      setEtagAction(store, href, ETAG_TRACKING, {etagValue});
+      setEtagAction(store, url, ETAG_TRACKING, {etagValue});
       Object.assign(details, {action: new Action(ETAG_TRACKING, {etagValue})});
       return true;
     }
   } else {
-    cache.set(href, {etagValue});
+    cache.set(url, {etagValue});
     return true;
   }
 }

--- a/src/js/reasons/etag.js
+++ b/src/js/reasons/etag.js
@@ -16,7 +16,7 @@ async function setEtagAction(store, url, reason, data={etagValue: null}) {
     return await store.setUrl(url, new Action(reason, data));
 }
 
-function etagHeader({store, cache}, details, header) {
+function etagHeader({store, unknownEtagCache}, details, header) {
   const {protocol, host, pathname} = details.urlObj,
     url  = `${protocol}//${host}${pathname}`,
     etagValue = header.value,
@@ -29,9 +29,9 @@ function etagHeader({store, cache}, details, header) {
       return false;
     }
   }
-  if (cache.has(url)) {
-    let oldEtagValue = cache.get(url).etagValue;
-    cache.delete(url)
+  if (unknownEtagCache.has(url)) {
+    let oldEtagValue = unknownEtagCache.get(url).etagValue;
+    unknownEtagCache.delete(url)
     if (etagValue === oldEtagValue) {
       // mark ETAG_SAFE
       setEtagAction(store, url, ETAG_SAFE, {etagValue});
@@ -43,7 +43,7 @@ function etagHeader({store, cache}, details, header) {
       return true;
     }
   } else {
-    cache.set(url, {etagValue});
+    unknownEtagCache.set(url, {etagValue});
     return true;
   }
 }

--- a/src/js/reasons/etag.js
+++ b/src/js/reasons/etag.js
@@ -3,7 +3,7 @@
 [(function(exports) {
 
 const {etag: {ETAG_TRACKING, ETAG_SAFE}} = require('../constants'),
-  {log} = require('../utils'),
+  {log, LruMap} = require('../utils'),
   {sendUrlDeactivate} = require('./utils'),
   {Action} = require('../schemes');
 
@@ -14,6 +14,11 @@ async function setEtagAction(store, url, reason, data={etagValue: null}) {
       etag value: ${data.etagValue}`);
     data.time = Date.now();
     return await store.setUrl(url, new Action(reason, data));
+}
+
+function newEtagHeaderFunc(store) {
+  let unknownEtagCache = new LruMap(2000);
+  return etagHeader.bind(undefined, {store, unknownEtagCache});
 }
 
 function etagHeader({store, unknownEtagCache}, details, header) {
@@ -60,6 +65,6 @@ const reason = {
   }
 }
 
-Object.assign(exports, {reason, etagHeader, setEtagAction});
+Object.assign(exports, {reason, etagHeader, setEtagAction, newEtagHeaderFunc});
 
 })].map(func => typeof exports == 'undefined' ? define('/reasons/etag', func) : func(exports));

--- a/src/js/reasons/headers.js
+++ b/src/js/reasons/headers.js
@@ -12,12 +12,12 @@ const alwaysTrue = () => true;
 
 class HeaderHandler {
   constructor(store) {
-    let cache = new LruMap(2000);
+    let unknownEtagCache = new LruMap(2000);
     this.badHeaders = new Map([
       ['cookie', alwaysTrue],
       ['set-cookie', alwaysTrue],
       ['referer', alwaysTrue],
-      ['etag', etagHeader.bind(undefined, {store, cache})],
+      ['etag', etagHeader.bind(undefined, {store, unknownEtagCache})],
       ['if-none-match', alwaysTrue]
     ]);
   }

--- a/src/js/reasons/headers.js
+++ b/src/js/reasons/headers.js
@@ -5,19 +5,18 @@
 const {Action} = require('../schemes'),
   {URL} = require('../shim'),
   {LruMap, hasAction} = require('../utils'),
-  {etagHeader} = require('./etag'),
+  {newEtagHeaderFunc} = require('./etag'),
   {HEADER_DEACTIVATE_ON_HOST, header_methods, NO_ACTION, TAB_DEACTIVATE_HEADERS} = require('../constants');
 
 const alwaysTrue = () => true;
 
 class HeaderHandler {
   constructor(store) {
-    let unknownEtagCache = new LruMap(2000);
     this.badHeaders = new Map([
       ['cookie', alwaysTrue],
       ['set-cookie', alwaysTrue],
       ['referer', alwaysTrue],
-      ['etag', etagHeader.bind(undefined, {store, unknownEtagCache})],
+      ['etag', newEtagHeaderFunc(store)],
       ['if-none-match', alwaysTrue]
     ]);
   }

--- a/src/js/test/reasons/etag_test.js
+++ b/src/js/test/reasons/etag_test.js
@@ -10,7 +10,7 @@ describe('etag.js', function() {
   let etagValue ='hi', href = 'https://foo.com/stuff.js';
   beforeEach(function() {
     this.store = new Store('name');
-    this.cache = new LruMap();
+    this.unknownEtagCache = new LruMap();
     this.etagHeader = etagHeader.bind(this, this);
     this.header = {name: 'etag', value: etagValue};
     this.details = {urlObj: {href}};

--- a/src/js/test/reasons/etag_test.js
+++ b/src/js/test/reasons/etag_test.js
@@ -2,7 +2,7 @@
 
 const {assert} = require('chai'),
   {Store} = require('../../store'),
-  {etagHeader, setEtagAction} = require('../../reasons/etag'),
+  {newEtagHeaderFunc, setEtagAction} = require('../../reasons/etag'),
   {LruMap} = require('../../utils'),
   {etag: {ETAG_TRACKING, ETAG_SAFE}} = require('../../constants');
 
@@ -10,8 +10,7 @@ describe('etag.js', function() {
   let etagValue ='hi', href = 'https://foo.com/stuff.js';
   beforeEach(function() {
     this.store = new Store('name');
-    this.unknownEtagCache = new LruMap();
-    this.etagHeader = etagHeader.bind(this, this);
+    this.etagHeader = newEtagHeaderFunc(this.store);
     this.header = {name: 'etag', value: etagValue};
     this.details = {urlObj: {href}};
 

--- a/src/js/test/reasons/etag_test.js
+++ b/src/js/test/reasons/etag_test.js
@@ -27,12 +27,7 @@ describe('etag.js', function() {
       let {details, header} = this;
 
       this.etagHeader(details, header);
-      let remove = this.etagHeader(details, header);
-      assert.isFalse(remove);
-
-      let action = this.store.getUrl(details.urlObj.href);
-      assert.equal(action.reason, ETAG_SAFE);
-      assert.equal(action.data.etagValue, header.value);
+      assert.isFalse(this.etagHeader(details, header));
     })
     it('blocks and marks as tracking on diff etag', async function() {
       let {details, header} = this,
@@ -55,13 +50,6 @@ describe('etag.js', function() {
 
       assert.equal(details.action.reason, ETAG_TRACKING);
       assert.isTrue(remove);
-    })
-    it('allows etags from safe urls', async function() {
-      let {details, header} = this;
-
-      await setEtagAction(this.store, href, ETAG_SAFE);
-      let remove = this.etagHeader(details, header);
-      assert.isFalse(remove);
     })
   });
 });


### PR DESCRIPTION
This makes some changes to the etag heuristic to make it take up less disk space.

We no longer store url's known to be safe on disk, instead we store them in a LRU cache