### PR TITLE
Add matchAboutBlank to chrome.tabs.executeScript

### DIFF
--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -204,7 +204,7 @@ class Tabs {
     const tab = this.getTab(tabId);
     if ((tabId >= 0) && tab && tab.active) {
       for (let file of contentScripts) {
-        await tabsExecuteScript(tabId, {frameId, runAt: 'document_start', file}, () => {
+        await tabsExecuteScript(tabId, {frameId, runAt: 'document_start', matchAboutBlank: true, file}, () => {
           if (errorOccurred()) {
             log(`cannot inject content script ${file} into url ${url} on tab ${tabId} and frame ${frameId}`);
           }


### PR DESCRIPTION
this fixes a bug where we wern't injecting code into about:blank and
srcdoc frames. Closes #60 