### PR TITLE
Add smarter referer blocking

### DIFF
--- a/src/js/reasons/headers.js
+++ b/src/js/reasons/headers.js
@@ -4,18 +4,20 @@
 
 const {Action} = require('../schemes'),
   {URL} = require('../shim'),
-  {LruMap, hasAction} = require('../utils'),
+  {hasAction} = require('../utils'),
   {newEtagHeaderFunc} = require('./etag'),
+  {Referer} = require('./referer'),
   {HEADER_DEACTIVATE_ON_HOST, header_methods, NO_ACTION, TAB_DEACTIVATE_HEADERS} = require('../constants');
 
 const alwaysTrue = () => true;
 
 class HeaderHandler {
   constructor(store) {
+    this.referer = new Referer();
     this.badHeaders = new Map([
       ['cookie', alwaysTrue],
       ['set-cookie', alwaysTrue],
-      ['referer', alwaysTrue],
+      ['referer', this.referer.shouldRemoveHeader.bind(this.referer)],
       ['etag', newEtagHeaderFunc(store)],
       ['if-none-match', alwaysTrue]
     ]);

--- a/src/js/reasons/referer.js
+++ b/src/js/reasons/referer.js
@@ -2,24 +2,7 @@
 
 [(function(exports) {
 
-const {LruMap} = require('../utils');
-
-function markHeadersMutated(details) {
-  details[details.headerPropName].mutated = true;
-}
-
-/* request thing:
- *
- *  remove referer, store requestId, & referer value
- *
- *  If this returns a 4xx, then redirect with the referer added back in.
- *  If this still fails, give up.
- */
-function refererHeader({requestIdCache}, details, header) {
-  header.value = details.url;
-  markHeadersMutated(details);
-  return false;
-}
+const {LruMap, log} = require('../utils');
 
 function is4xx(statusCode) {
   return (400 <= statusCode) && (statusCode < 500);
@@ -45,15 +28,16 @@ class Referer {
     }
 
     if (this.failedAlready(details)) {
+      log('failed referer already');
       return false;
     }
-
     return true;
   }
 
   onHeadersReceived(details) {
     if (this.removeRefererFailedOnce(details)) {
       this.badRedirects.set(details.requestId);
+      log(`failed referer removal, redirecting ${details.url}`);
       return details.response = {redirectUrl: details.url};
     }
   }

--- a/src/js/reasons/referer.js
+++ b/src/js/reasons/referer.js
@@ -38,6 +38,7 @@ class Referer {
     if (this.removeRefererFailedOnce(details)) {
       this.badRedirects.set(details.requestId);
       log(`failed referer removal, redirecting ${details.url}`);
+      details.shortCircuit = true;
       return details.response = {redirectUrl: details.url};
     }
   }

--- a/src/js/reasons/referer.js
+++ b/src/js/reasons/referer.js
@@ -1,0 +1,53 @@
+"use strict";
+
+[(function(exports) {
+
+const {LruMap} = require('../utils');
+
+function markHeadersMutated(details) {
+  details[details.headerPropName].mutated = true;
+}
+
+/* request thing:
+ *
+ *  remove referer, store requestId, & referer value
+ *
+ *  If this returns a 4xx, then redirect with the referer added back in.
+ *  If this still fails, give up.
+ */
+function refererHeader({requestIdCache}, details, header) {
+  header.value = details.url;
+  markHeadersMutated(details);
+  return false;
+}
+
+class Referer {
+  constructor() {
+    this.requestIdCache = new LruMap(1000);
+    this.badRedirects = new Set();
+  }
+
+  removeRefererFailed({statusCode, requestId}) {
+    return ((400 <= statusCode) && (statusCode < 500)) && this.requestId.has(requestId) && !this.badRedirects.has(requestId);
+  }
+
+  onBeforeSendHeaders(details, header) {
+    if (this.failedAlready(details)) {
+      return false;
+    }
+    return true;
+  }
+
+  onHeadersReceived(details) {
+    if (this.removeRefererFailedOnce(details)) {
+      this.badRedirects.add(details.requestId);
+      return {redirectUrl: details.url}
+    }
+  }
+  onBeforeRedirect(details) {
+  }
+}
+
+Object.assign(exports, {Referer});
+
+})].map(func => typeof exports == 'undefined' ? define('/reasons/referer', func) : func(exports));

--- a/src/js/test/reasons/referer_test.js
+++ b/src/js/test/reasons/referer_test.js
@@ -4,7 +4,41 @@ const {assert} = require('chai'),
   {Referer} = require('../../reasons/referer');
 
 describe('referer.js', function() {
-  it('Referer', async function() {
-    const referer = new Referer();
+  let requestId = 1,
+    url = 'https://whatever.com/nope';
+  beforeEach(function() {
+    this.details = {requestId, url};
+    this.header = {name: 'Referer', value: 'https://foo.com/stuff'};
+    this.referer = new Referer();
+  });
+  describe('#shouldRemoveHeader', function() {
+    it('removes first', function() {
+      assert.isTrue(this.referer.shouldRemoveHeader(this.details, this.header));
+    });
+    it('does not remove when failedAlready', function() {
+      this.referer.badRedirects.set(requestId);
+      assert.isFalse(this.referer.shouldRemoveHeader(this.details, this.header));
+    });
+  });
+
+  describe('#onHeadersReceived', function() {
+    it('no action for non-400 responses', function() {
+      assert.isUndefined(this.referer.onHeadersReceived({statusCode: 200}));
+    });
+    describe('sent', function() {
+      beforeEach(function() {
+        this.referer.shouldRemoveHeader(this.details, this.header);
+      });
+      it('no actionn for already failed but 400 again responses', function() {
+        this.referer.badRedirects.set(requestId);
+        assert.isUndefined(this.referer.onHeadersReceived({requestId, statusCode: 403}));
+      });
+      it('redirects on first 400', function() {
+        let {details} = this,
+          statusCode = 403;
+        Object.assign(details, {statusCode});
+        assert.deepEqual(this.referer.onHeadersReceived(details), {redirectUrl: details.url});
+      });
+    });
   });
 });

--- a/src/js/test/reasons/referer_test.js
+++ b/src/js/test/reasons/referer_test.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const {assert} = require('chai'),
+  {Referer} = require('../../reasons/referer');
+
+describe('referer.js', function() {
+  it('Referer', async function() {
+    const referer = new Referer();
+  });
+});

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -105,8 +105,12 @@ class WebRequest {
     return details.response;
   }
 
-  checkOnHeadersReceived(details) {
-    return this.handler.headerHandler.referer.onHeadersReceived(details);
+  requestOrResponseAction(details) {
+    if (!details.shortCircuit) {
+      if (details.requestType == ON_HEADERS_RECEIVED) {
+        return this.handler.headerHandler.referer.onHeadersReceived(details);
+      }
+    }
   }
 
   headerHandler(details) {
@@ -114,7 +118,7 @@ class WebRequest {
       let headers = details[details.headerPropName],
         removed = this.removeHeaders(details, headers);
       this.checkAllRequestActions(details);
-      this.checkOnHeadersReceived(details);
+      this.requestOrResponseAction(details);
       if (!details.shortCircuit && (removed.length || headers.mutated)) {
         details.response = {[details.headerPropName]: headers};
         this.markHeaders(removed, details);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -104,11 +104,16 @@ class WebRequest {
     return details.response;
   }
 
+  checkOnHeadersReceived(details) {
+    return this.handler.headerHandler.referer.onHeadersReceived(details);
+  }
+
   headerHandler(details) {
     if (this.isThirdParty(details)) {
       let headers = details[details.headerPropName],
         removed = this.removeHeaders(details, headers);
       this.checkAllRequestActions(details);
+      this.checkOnHeadersReceived(details);
       if (!details.shortCircuit && (removed.length || headers.mutated)) {
         details.response = {[details.headerPropName]: headers};
         this.markHeaders(removed, details);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -109,7 +109,7 @@ class WebRequest {
       let headers = details[details.headerPropName],
         removed = this.removeHeaders(details, headers);
       this.checkAllRequestActions(details);
-      if (!details.shortCircuit && removed.length) {
+      if (!details.shortCircuit && (removed.length || headers.mutated)) {
         details.response = {[details.headerPropName]: headers};
         this.markHeaders(removed, details);
       }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -5,6 +5,7 @@
 const shim = require('./shim'), {URL} = shim,
   constants = require('./constants'),
   {header_methods, request_methods} = constants,
+  {ON_BEFORE_REQUEST, ON_BEFORE_SEND_HEADERS, ON_HEADERS_RECEIVED} = request_methods,
   {Handler} = require('./reasons/handlers');
 
 function annotateDetails(details, requestType) {
@@ -85,20 +86,20 @@ class WebRequest {
   }
 
   onBeforeRequest(details) {
-    annotateDetails(details, request_methods.ON_BEFORE_REQUEST);
+    annotateDetails(details, ON_BEFORE_REQUEST);
     this.recordRequest(details);
     return this.commitRequest(details);
   }
 
   onBeforeSendHeaders(details) {
-    annotateDetails(details, request_methods.ON_BEFORE_SEND_HEADERS);
+    annotateDetails(details, ON_BEFORE_SEND_HEADERS);
     this.headerHandler(details);
     this.markAction(details);
     return details.response;
   }
 
   onHeadersReceived(details) {
-    annotateDetails(details, request_methods.ON_HEADERS_RECEIVED);
+    annotateDetails(details, ON_HEADERS_RECEIVED);
     this.headerHandler(details);
     this.markAction(details);
     return details.response;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -55,6 +55,7 @@
       "js/reasons/reasons.js",
       "js/reasons/fingerprinting.js",
       "js/reasons/user_url_deactivate.js",
+      "js/reasons/referer.js",
       "js/reasons/headers.js",
       "js/reasons/etag.js",
       "js/reasons/utils.js",

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -14,6 +14,7 @@
   <script type="text/javascript" src="/js/reasons/user_url_deactivate.js"></script>
   <script type="text/javascript" src="/js/reasons/headers.js"></script>
   <script type="text/javascript" src="/js/reasons/etag.js"></script>
+  <script type="text/javascript" src="/js/reasons/referer.js"></script>
 
   <script type="text/javascript" src="/js/popup.js"></script>
   <script type="text/javascript" src="/js/initialize_popup.js"></script>


### PR DESCRIPTION
This starts building out a system for being smarter about referer blocking. The current system I'm working on:
* block all third party referers in requests
* if the response has a 4XX status code - retry with the original referer

This should solve issues like #57 and #25 while still preserving privacy where possible. And without maintaining a whitelist.