### PR TITLE
WIP: use user interactions to whitelist hosts.

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -50,6 +50,7 @@ const header_methods = new Map([
 // reasons
 // todo move these into their own namespace
 const FINGERPRINTING = 'fingerprinting',
+  INTERACTION = 'interaction',
   USER_HOST_DEACTIVATE = 'user_host_deactivate',
   USER_URL_DEACTIVATE = 'user_url_deactivate',
   BLOCK = 'block',
@@ -86,6 +87,7 @@ Object.assign(exports, {
   reasons,
   request_methods,
   header_methods,
+  INTERACTION,
   FINGERPRINTING,
   FINGERPRINTING_PATH,
   USER_HOST_DEACTIVATE,

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -56,7 +56,10 @@ const FINGERPRINTING = 'fingerprinting',
   BLOCK = 'block',
   HEADER_DEACTIVATE_ON_HOST = 'header_deactivate_on_host';
 
-const FINGERPRINTING_PATH = '/js/contentscripts/injector.js';
+const CONTENTSCRIPT_PATHS = new Set([
+  '/js/contentscripts/injector.js',
+  '/js/contentscripts/interacted.js'
+]);
 
 const etag = {
   ETAG_TRACKING: 'etag_tracking',
@@ -87,9 +90,9 @@ Object.assign(exports, {
   reasons,
   request_methods,
   header_methods,
+  CONTENTSCRIPT_PATHS,
   INTERACTION,
   FINGERPRINTING,
-  FINGERPRINTING_PATH,
   USER_HOST_DEACTIVATE,
   USER_URL_DEACTIVATE,
   BLOCK,

--- a/src/js/contentscripts/interacted.js
+++ b/src/js/contentscripts/interacted.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const INTERACTION = 'interaction';
+
+function urlToHostname(url) {
+  return (new URL(url)).hostname;
+}
+
+document.addEventListener('mousedown', function(e) {
+  if (e.isTrusted) {
+    chrome.runtime.sendMessage({
+      type: INTERACTION,
+      hostname: urlToHostname(e.target.baseURI)
+    });
+  }
+});

--- a/src/js/reasons/interacted.js
+++ b/src/js/reasons/interacted.js
@@ -1,0 +1,22 @@
+"use strict";
+
+[(function(exports) {
+
+const {INTERACTION} = require('../constants');
+
+function onMessage({tabs}, message, sender) {
+  let tabId = sender.tab.id,
+    {hostname} = message;
+  tabs.updateInteractionWhitelist(tabId, hostname);
+}
+
+const reason = {
+  name: INTERACTION,
+  props: {
+    messageHandler: onMessage,
+  }
+}
+
+Object.assign(exports, {reason});
+
+})].map(func => typeof exports == 'undefined' ? define('/reasons/interacted', func) : func(exports));

--- a/src/js/reasons/reasons.js
+++ b/src/js/reasons/reasons.js
@@ -149,6 +149,7 @@ reasonsArray.push(require('./user_url_deactivate').urlDeactivateReason);
 reasonsArray.push(require('./headers').reason);
 reasonsArray.push(require('./headers').tabReason);
 reasonsArray.push(require('./etag').reason);
+reasonsArray.push(require('./interacted').reason);
 
 Object.assign(exports, {Reasons, reasonsArray, tabDeactivate, blockAction, Reason});
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -7,11 +7,9 @@
 [(function(exports) {
 
 const shim = require('./shim'), {URL, tabsGet, tabsQuery, tabsExecuteScript} = shim,
-  {REMOVE_ACTION, FINGERPRINTING_PATH} = require('./constants'),
+  {REMOVE_ACTION, CONTENTSCRIPT_PATHS} = require('./constants'),
   {errorOccurred, Counter, listenerMixin, setTabIconActive, safeSetBadgeText, log} = require('./utils'),
   {isThirdParty} = require('./domains/parties');
-
-const contentScripts = new Set([FINGERPRINTING_PATH]);
 
 class Resource {
   constructor({url, method, type}) {
@@ -203,7 +201,7 @@ class Tabs {
   async onNavigationCommitted({tabId, frameId, url}) {
     const tab = this.getTab(tabId);
     if ((tabId >= 0) && tab && tab.active) {
-      for (let file of contentScripts) {
+      for (let file of CONTENTSCRIPT_PATHS) {
         await tabsExecuteScript(tabId, {frameId, runAt: 'document_start', matchAboutBlank: true, file}, () => {
           if (errorOccurred()) {
             log(`cannot inject content script ${file} into url ${url} on tab ${tabId} and frame ${frameId}`);

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -64,9 +64,15 @@ class Tab extends listenerMixin(Map) {
     this.actions = new Map();
     this.headerCounts = new Counter();
     this.headerCountsActive = true;
+    this.interactionWhiteList = new Set();
 
     this.onChange = this.onEvent;
     this.updateBadge();
+  }
+
+  updateInteractionWhitelist(hostname) {
+    log(`update interaction whitelist with ${hostname}`);
+    this.interactionWhiteList.add(hostname);
   }
 
   // merge from anotherTab, don't overite own values
@@ -157,6 +163,10 @@ class Tabs {
         });
       });
     });
+  }
+
+  updateInteractionWhitelist(tabId, hostname) {
+    this.getTab(tabId).updateInteractionWhitelist(hostname);
   }
 
   async startListeners({onRemoved, onErrorOccurred, onNavigationCommitted} = shim) {

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -75,6 +75,14 @@ class Tab extends listenerMixin(Map) {
     this.interactionWhiteList.add(hostname);
   }
 
+  isThirdParty(hostname) {
+    if (!this.interactionWhiteList.has(hostname)) {
+      let tabhost = this.get(0).urlObj.hostname
+      return isThirdParty(tabhost, hostname);
+    }
+    return false;
+  }
+
   // merge from anotherTab, don't overite own values
   merge(otherTab) {
     this.headerCounts.merge(otherTab.headerCounts);
@@ -255,8 +263,7 @@ class Tabs {
 
   isThirdParty(tabId, hostname) {
     try {
-      let tabhost = this.getFrame(tabId, 0).urlObj.hostname
-      return isThirdParty(tabhost, hostname);
+      return this.getTab(tabId).isThirdParty(hostname);
     } catch (e) {
       log(`error getting tab data for tabId ${tabId} with error ${e.stack}`);
       return false;

--- a/src/js/test/tabs_test.js
+++ b/src/js/test/tabs_test.js
@@ -20,6 +20,20 @@ describe('tabs.js', function() {
       this.tab = this.tabs.getTab(main_frame.tabId);
     });
 
+    describe('#isThirdParty', function() {
+      it('false when 1st party', function () {
+        assert.isFalse(this.tabs.isThirdParty(tabId, 'google.com'));
+      });
+      it('true when 3rd party', function () {
+        assert.isTrue(this.tabs.isThirdParty(tabId, 'thirdparty.com'));
+      });
+      it('counts interacted with stuff as 1st party', function () {
+        let hostname = 'interacted.com';
+        this.tabs.updateInteractionWhitelist(tabId, hostname);
+        assert.isFalse(this.tabs.isThirdParty(tabId, hostname));
+      });
+    }),
+
     it('#getTabUrl', function() {
       assert.equal(this.tabs.getTabUrl(1), 'https://google.com/');
       assert.isUndefined(this.tabs.getTabUrl('not present'));

--- a/src/js/test/tabs_test.js
+++ b/src/js/test/tabs_test.js
@@ -41,7 +41,7 @@ describe('tabs.js', function() {
 
       it('injects when onNavigationComitted fires', async function() {
         await onNavigationCommitted.sendMessage({tabId, frameId, url});
-        assert.equal(tabsExecuteScript.onMessage.messages.length, 1);
+        assert.isTrue(tabsExecuteScript.onMessage.messages.length > 0);
       });
       it('does not inject when tab is deactivated', async function() {
         this.tab.setActiveState(false)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -60,6 +60,7 @@
       "js/reasons/etag.js",
       "js/reasons/utils.js",
       "js/reasons/handlers.js",
+      "js/reasons/interacted.js",
       "js/tabs.js",
 
       "js/schemes.js",


### PR DESCRIPTION
This implements something like what Cliqz does, as described by this [this issue](https://github.com/cliqz-oss/browser-core/issues/58).

We create an ephemeral whitelist of domains from user interactions, then check this whitelist when we call `isThirdParty`

Todo:
* we should probably attach the whitelist to `Tabs` instead of each `Tab`.
* add tests
* actually find a domain where this fixes an issue, and test it
* make the whitelist a FIFO cache
* cache duplicate user interactions in the contentscript so we don't send too many messages

Related to #72 and #4 