### PR TITLE
Allow setting properties being watched for fingerprinting.

### DIFF
--- a/src/js/web_accessible/fingercounting.js
+++ b/src/js/web_accessible/fingercounting.js
@@ -194,8 +194,7 @@ class Counter {
       propName = arr.pop();
 
     let baseObj = arr.reduce((o, i) => o[i], this.globalObj);
-    const before = baseObj[propName];
-
+    let before = baseObj[propName];
     try {
       Object.defineProperty(baseObj, propName, {
         get: function() {
@@ -204,7 +203,11 @@ class Counter {
             return lieFunc(before);
           }
           return before;
-        }
+        },
+        set: function(value) {
+          return before = value;
+        },
+        configurable: true,
       });
     } catch (ignore) {
       // property probably non-configurable from other userscript


### PR DESCRIPTION
closes #72 

Setting properties that we watch for fingerprinting was throwing errors in strict mode. We now allow these to be set, while continuing to watch them for fingerprinting.

We also add some tests for this.