### PR TITLE
added short_name

### DIFF
--- a/docs/notes.md
+++ b/docs/notes.md
@@ -33,7 +33,6 @@
 * error when inspect popup creates it, make currentTab work with this
 * fix webrequest requestHandler loop
 * change badge text color to grey
-* add short name to manifest for chrome store
 * make icon not blurry in chrome store?
 * add screenshots for chrome store, resize current ones to 1280 pixels wide and 800 pixels high
 * add video of fingerprint blocking

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,7 @@
 {
   "version": "2018.7.28",
-  "name": "Privacy Possum",
+  "name": "Privacy Possum - blocking commercial tracking",
+  "short_name": "Privacy Possum",
   "author": "cowlicks@riseup.net",
   "manifest_version": 2,
   "applications": {


### PR DESCRIPTION
From your todo-list:
> add short name to manifest for chrome store

adds [`short_name`](https://developer.chrome.com/apps/manifest/name#short_name) and therefore I would make the normal name a bit "longer" or more informative.