### PR TITLE
Add selenium tests

### DIFF
--- a/src/js/package.json
+++ b/src/js/package.json
@@ -5,14 +5,15 @@
   "main": "utils.js",
   "dependencies": {},
   "devDependencies": {
-    "react": "file:./external/react",
-    "react-dom": "file:./external/react-dom",
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
     "jsdom": "^11.10.0",
     "mocha": "^4.1.0",
-    "nyc": "^11.7.3"
+    "nyc": "^11.7.3",
+    "react": "file:./external/react",
+    "react-dom": "file:./external/react-dom",
+    "selenium-webdriver": "^4.0.0-alpha.1"
   },
   "scripts": {
     "test": "mocha --recursive",

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "test": "mocha --recursive",
+    "selenium": "node ./selenium/selenium.js",
     "lint": "git ls-files | grep \".js$\" | grep -v \"external\" | xargs eslint",
     "loc": "git ls-files | grep -v 'psl.js' | xargs cat | wc -l",
     "cover": "nyc --reporter=html --reporter=text mocha",

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -8,12 +8,14 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
+    "express": "^4.16.3",
     "jsdom": "^11.10.0",
     "mocha": "^4.1.0",
     "nyc": "^11.7.3",
     "react": "file:./external/react",
     "react-dom": "file:./external/react-dom",
-    "selenium-webdriver": "^4.0.0-alpha.1"
+    "selenium-webdriver": "^4.0.0-alpha.1",
+    "vhost": "^3.0.2"
   },
   "scripts": {
     "test": "mocha --recursive",

--- a/src/js/selenium/etagApp.js
+++ b/src/js/selenium/etagApp.js
@@ -1,0 +1,47 @@
+const express = require('express'),
+  vhost = require('vhost');
+
+class App {
+  constructor(host, port) {
+  }
+}
+
+module.exports = port => {
+  const firstApp = express();
+  firstApp.get('/', (req, res) => {
+    console.log('got a reqest');
+    return res.send(
+`<script type="text/javascript" src="http://thirdpartywithetag.local:${port}/tracker.js"></script>`
+    );
+  });
+  return firstApp;
+}
+
+/*
+ * todo finish implementing the etag test based on this flask code
+
+from flask import Flask, Response, request
+app = Flask(__name__)
+
+@app.route('/')
+def hello_world():
+    return '''
+<script type="text/javascript" src="http://le.wtf:5000/tracker.js"></script>
+Hello, World!
+'''
+
+@app.route('/tracker.js')
+def tracker(): 
+    resp = Response('document.documentElement.appendChild(document.createTextNode("foobar"))')
+    req_if_none_match = request.headers.get('if-none-match')
+    if (req_if_none_match and req_if_none_match.startswith('count:')):
+        this_count = int(req_if_none_match.split(':')[-1])
+        etag = 'count:%s' % (this_count + 1)
+        print('increment');
+    else:
+        print('fresh')
+        etag = 'count:0'
+    resp.headers['etag'] = etag
+    print(etag);
+    return resp
+    */

--- a/src/js/selenium/selenium.js
+++ b/src/js/selenium/selenium.js
@@ -1,0 +1,39 @@
+const sw = require('selenium-webdriver'),
+  express = require('express'),
+  vhost = require('vhost'),
+  etagApp = require("./etagApp");
+
+const PORT = 8000;
+
+/*
+ * in /etc/hosts this requires:
+ * 127.0.0.1    etag.local
+ * 127.0.0.1    thirdpartywithetag.local
+ */
+
+function loadDriverWithExtension(extPath) {
+  let chromeOptions = sw.Capabilities.chrome();
+  chromeOptions.set("chromeOptions",  {"args": ['--load-extension='+extPath]});
+  return new sw.Builder()
+      .forBrowser('chrome')
+      .withCapabilities(chromeOptions)
+      .build();
+}
+
+function startApps() {
+  let appWithVhost = module.exports = express();
+  appWithVhost.use(vhost('etag.local', etagApp(PORT))); // Serves first app
+  //appWithVhost.use(vhost('admin.mydomain.local', app2)); // Serves second app
+
+  /* istanbul ignore next */
+  if (!module.parent) {
+    appWithVhost.listen(PORT);
+    console.log(`Express started on port ${PORT}`);
+  }
+}
+
+let path = '../.',
+  driver = loadDriverWithExtension(path);
+startApps();
+
+driver.get('etag.local:8000');


### PR DESCRIPTION
Closes #7

Currently this is just a dump of code that:
* Uses selenium to run chrome with Privacy Possum installed
* Start a simple express app
* visit the express app with the chrome instance

Now that we have something to build off, we need to:
* Make an express app to serve some in-browser unit tests
* finish the etag test, and add more complex tests
* Move the tests out a directory that is packaged with the extension
* update the .travis.yml to run these headlessley
* run the tests in firefox

I'll probably merge this as soon as it can run on travis-ci to be useful. The rest of the unfinished stuff can be made into separate issues.