### PR TITLE
Improve isRequestThirdParty using details.initiator

### DIFF
--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -246,7 +246,7 @@ class Tabs {
     return this.getTab(tabId).get(frameId);
   }
 
-  isRequestThirdParty({tabId, initiator, urlObj: {hostname}}) {
+  isRequestThirdParty({tabId, initiator, urlObj: {hostname} = {}}) {
     if (typeof initiator !== 'undefined') {
       return isThirdParty((new URL(initiator)).hostname, hostname);
     }

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -238,14 +238,12 @@ class Tabs {
     return this.getTab(tabId).get(frameId);
   }
 
-  isRequestThirdParty(details) {
-    let {tabId, initiator, urlObj: {hostname}} = details;
+  isRequestThirdParty({tabId, initiator, urlObj: {hostname}}) {
+    if (typeof initiator !== 'undefined') {
+      return isThirdParty((new URL(initiator)).hostname, hostname);
+    }
     if (tabId === -1) {
-      if (typeof initiator !== 'undefined') {
-        let initiatorHostname = (new URL(initiator)).hostname;
-        return isThirdParty(initiatorHostname, hostname);
-      }
-      return false; // no associated tab, so 3rd party isn't applicable
+      return false; // no associated tab and no initiator info so we don't know
     }
     return this.isThirdParty(tabId, hostname);
   }

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -218,6 +218,14 @@ class Tabs {
     }
   }
 
+  getTabHostname(tabId) {
+    try {
+      return this.getFrame(tabId, 0).urlObj.hostname
+    } catch(e) {
+      return undefined;
+    }
+  }
+
   getTabUrl(tabId) {
     try {
       return this.getFrameUrl(tabId, 0);
@@ -249,13 +257,12 @@ class Tabs {
   }
 
   isThirdParty(tabId, hostname) {
-    try {
-      let tabhost = this.getFrame(tabId, 0).urlObj.hostname
-      return isThirdParty(tabhost, hostname);
-    } catch (e) {
-      log(`error getting tab data for tabId ${tabId} with error ${e.stack}`);
+    let tabHost = this.getTabHostname(tabId);
+    if (!tabHost) {
+      log(`could not calculate tabhost for isThirdParty with hostname ${hostname} on tabId ${tabId}`);
       return false;
     }
+    return isThirdParty(tabHost, hostname);
   }
 
   hasResource({tabId, frameId, url, type}) {

--- a/src/js/test/tabs_test.js
+++ b/src/js/test/tabs_test.js
@@ -8,7 +8,8 @@ let assert = require('chai').assert,
   {Tab, Tabs} = require('../tabs');
 
 const tabId = 1,
-  main_frame = {frameId: 0, url: 'https://google.com/', tabId, parentFrameId: -1, type: 'main_frame'},
+  firstParty = 'https://google.com/', thirdParty = 'https://third.com/',
+  main_frame = {frameId: 0, url: firstParty, tabId, parentFrameId: -1, type: 'main_frame'},
   sub_frame = {frameId: 1, url: 'about:blank', tabId, parentFrameId: 0, type: 'sub_frame'};
 
 describe('tabs.js', function() {
@@ -30,6 +31,26 @@ describe('tabs.js', function() {
 
         await this.tabs.getCurrentData();
         assert.isUndefined(this.tabs.getFrame(id, 1));
+      });
+    });
+    describe('#isRequestThirdParty', function() {
+      it('no initiator', function() {
+        let details = {tabId: 1, urlObj: new URL(thirdParty)};
+        assert.isTrue(this.tabs.isRequestThirdParty(details));
+      });
+      it('has initiator', function() {
+        let isFirst = {initiator: firstParty, urlObj: new URL(firstParty)},
+          isThird = {initiator: firstParty, urlObj: new URL(thirdParty)};
+        assert.isFalse(this.tabs.isRequestThirdParty(isFirst));
+        assert.isTrue(this.tabs.isRequestThirdParty(isThird));
+      });
+      it('no initiator tabId = -1', function() {
+        assert.isFalse(this.tabs.isRequestThirdParty({tabId: -1}));
+      });
+      it('no initiator, no prexisting data about tab', function() {
+        this.tabs = new Tabs();
+        let details = {tabId: 1, urlObj: new URL(thirdParty)};
+        assert.isFalse(this.tabs.isRequestThirdParty(details));
       });
     });
 

--- a/src/js/test/tabs_test.js
+++ b/src/js/test/tabs_test.js
@@ -20,8 +20,6 @@ describe('tabs.js', function() {
       this.tab = this.tabs.getTab(main_frame.tabId);
     });
     describe('#getCurrentData', function() {
-      beforeEach(function() {
-      });
       it('does not get frames from "discarded" tabs', async function() {
         let discarded = true, id = 2, url = 'https://url.com/';
         tabsQuery.tabs = [{id, discarded, url}];


### PR DESCRIPTION
We now make it use `details.initiator` as much as possible. This closes #89. Adds tests for `Tabs.isRequestThirdParty`.

For posterity, the way I was able to start Firefox with the development addon installed was:
* Use firefox development edition
* goto about:config and set `xpinstall.signatures.required = false`
* Build extension with web-ext
* drag built extension into about:addons to install it
* set homepage to the broken site  (netvibes.com)
* close firefox and re-open it